### PR TITLE
static versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,8 +18,8 @@
         <url>scm:git:git@github.com:shred/shariff-backend-java.git</url>
         <connection>scm:git:git@github.com:shred/shariff-backend-java.git</connection>
         <developerConnection>scm:git:git@github.com:shred/shariff-backend-java.git</developerConnection>
-      <tag>HEAD</tag>
-  </scm>
+        <tag>HEAD</tag>
+    </scm>
     <developers>
         <developer>
             <id>shred</id>
@@ -28,7 +28,7 @@
     </developers>
     <properties>
         <json.version>20160810</json.version>
-        <slf4j.version>[1.7.0,)</slf4j.version>
+        <slf4j.version>1.7.25</slf4j.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     </properties>
@@ -135,19 +135,19 @@
         <dependency>
             <groupId>org.hamcrest</groupId>
             <artifactId>hamcrest-library</artifactId>
-            <version>[1.3,)</version>
+            <version>1.3</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>[2.0,)</version>
+            <version>2.23.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>[4,)</version>
+            <version>4.12</version>
             <scope>test</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
Hey, 

I wanted to add some things to your shariff backend to replace our old backend https://github.com/headissue/shariff-backend-java
On cloning the projekt, my IDE downloaded a lot of 'mockito v... beta' dependencies, which seems unnecessary. Would it be ok to change that to static versions?

Kind reagards
globalworming  