### PR TITLE
append to user agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ The following configuration options are available:
 | `threads`   | Number of fetcher threads. Defaults to number of active targets. |
 | `facebook.id` | The app ID of your Facebook application. |
 | `facebook.secret` | The app secret of your Facebook application. |
+| `organisation` | When set, your organisation will appear in the user agent of any request which is made by the shariff backend |
 
 Note that you _must_ set up `facebook.id` and `facebook.secret` to retrieve a valid Facebook share counter. Facebook does not offer an anonymous way any more, at least none I am aware of.
 

--- a/src/main/java/org/shredzone/shariff/ShariffServlet.java
+++ b/src/main/java/org/shredzone/shariff/ShariffServlet.java
@@ -27,6 +27,7 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 import org.json.JSONObject;
+import org.shredzone.shariff.api.HttpTarget;
 import org.shredzone.shariff.target.Facebook;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -204,6 +205,11 @@ public class ShariffServlet extends HttpServlet {
 
         fbClientId = config.getInitParameter("facebook.id");
         fbClientSecret = config.getInitParameter("facebook.secret");
+
+        String organisation = config.getInitParameter("organisation");
+        if (organisation != null) {
+            HttpTarget.organisation = organisation;
+        }
     }
 
     @Override

--- a/src/main/java/org/shredzone/shariff/api/HttpTarget.java
+++ b/src/main/java/org/shredzone/shariff/api/HttpTarget.java
@@ -28,21 +28,21 @@ import java.util.Properties;
 public abstract class HttpTarget implements Target {
 
     private static final int HTTP_TIMEOUT_MS = 10000;
-    private static final String USER_AGENT;
+    private static final String BACKEND_VERSION;
+    public static String organisation;
 
     static {
-        StringBuilder agent = new StringBuilder("shariff-backend-java");
+        StringBuilder version = new StringBuilder("shariff-backend-java");
         try {
             Properties prop = new Properties();
             prop.load(HttpTarget.class.getResourceAsStream("/org/shredzone/shariff/version.properties"));
-            agent.append('/').append(prop.getProperty("version"));
+            version.append('/').append(prop.getProperty("version"));
         } catch (IOException ex) {
             throw new UncheckedIOException(ex);
         }
 
-        agent.append(" Java/").append(System.getProperty("java.version"));
-
-        USER_AGENT = agent.toString();
+        version.append(" Java/").append(System.getProperty("java.version"));
+        BACKEND_VERSION = version.toString();
     }
 
     @Override
@@ -104,8 +104,15 @@ public abstract class HttpTarget implements Target {
         connection.setUseCaches(false);
         connection.setConnectTimeout(HTTP_TIMEOUT_MS);
         connection.setReadTimeout(HTTP_TIMEOUT_MS);
-        connection.setRequestProperty("User-Agent", USER_AGENT);
+        connection.setRequestProperty("User-Agent", getUserAgent());
         return connection;
     }
 
+    private String getUserAgent() {
+        String userAgent = BACKEND_VERSION;
+        if (organisation != null) {
+            userAgent += " (" + organisation + ")";
+        }
+        return userAgent;
+    }
 }


### PR DESCRIPTION
Hi, 

I'd like to customize the request user agent because:
* we see it as best practice to provide a way to contact us in the user agent
* when testing locally, reddit returns a [429 too many requests](https://www.reddit.com/r/redditdev/comments/3qbll8/429_too_many_requests/) which may be caused by the generic user agent in use

The change is quick and dirty. A better solution would require to factor out the whole connection part. Which would be more testable and more "separation of concerns".. 
Please let me know if you would like to see a better (cost/benefit) solution 